### PR TITLE
Fix peculiar bug regarding Clear Grid button in EDM Composer

### DIFF
--- a/src/components/composer.tsx
+++ b/src/components/composer.tsx
@@ -315,7 +315,14 @@ export default function Composer({ library: globalLibrary }: ComposerProps) {
             </div>
           </div>
 
-          <Button variant="ghost" size="sm" onClick={() => saveComp(INITIAL_COMPOSITION)} className="text-muted-foreground hover:text-destructive h-9 rounded-xl">
+          <Button variant="ghost" size="sm" onClick={() => saveComp({
+            ...INITIAL_COMPOSITION,
+            tracks: INITIAL_COMPOSITION.tracks.map(track => ({
+              ...track,
+              steps: [...track.steps],
+              stepNotes: [...track.stepNotes]
+            }))
+          })} className="text-muted-foreground hover:text-destructive h-9 rounded-xl">
             <Trash2 className="w-4 h-4 mr-2" />
             Clear Grid
           </Button>


### PR DESCRIPTION
This issue is very very peculiar to describe and all I can do is to just create a video on the issue. First tab is upstream, Second is localhost. The clear grid button sometimes does not work upon clicking "Clear Grid". This PR fixes the issue.


https://github.com/user-attachments/assets/6fcc34d4-af9d-4bfb-9255-116020632b2b

